### PR TITLE
Add reasoning configuration options to settings schema

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -124,7 +124,33 @@ Settings are organized into categories. All settings should be placed within the
         "temperature": 0.2,
         "top_p": 0.8,
         "max_tokens": 1024
+      },
+      "reasoning": {
+        "effort": "medium"
       }
+    }
+  }
+}
+```
+
+**Reasoning Configuration:**
+
+The `reasoning` field controls reasoning behavior for models that support it:
+
+- Set to `false` to disable reasoning entirely
+- Set to an object with `effort` field to enable reasoning with a specific effort level:
+  - `"low"`: Minimal reasoning effort
+  - `"medium"`: Balanced reasoning effort (default)
+  - `"high"`: Maximum reasoning effort
+- Optionally include `budget_tokens` to limit reasoning token usage
+
+Example to disable reasoning:
+
+```json
+{
+  "model": {
+    "generationConfig": {
+      "reasoning": false
     }
   }
 }

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -675,6 +675,45 @@ const SETTINGS_SCHEMA = {
               { value: 'openapi_30', label: 'OpenAPI 3.0 Strict' },
             ],
           },
+          samplingParams: {
+            type: 'object',
+            label: 'Sampling Parameters',
+            category: 'Generation Configuration',
+            requiresRestart: false,
+            default: undefined as
+              | {
+                  top_p?: number;
+                  top_k?: number;
+                  repetition_penalty?: number;
+                  presence_penalty?: number;
+                  frequency_penalty?: number;
+                  temperature?: number;
+                  max_tokens?: number;
+                }
+              | undefined,
+            description: 'Sampling parameters for content generation.',
+            parentKey: 'generationConfig',
+            childKey: 'samplingParams',
+            showInDialog: false,
+          },
+          reasoning: {
+            type: 'object',
+            label: 'Reasoning Configuration',
+            category: 'Generation Configuration',
+            requiresRestart: false,
+            default: undefined as
+              | false
+              | {
+                  effort?: 'low' | 'medium' | 'high';
+                  budget_tokens?: number;
+                }
+              | undefined,
+            description:
+              'Reasoning configuration for models that support reasoning. Set to false to disable reasoning, or provide an object with effort level and optional token budget.',
+            parentKey: 'generationConfig',
+            childKey: 'reasoning',
+            showInDialog: false,
+          },
         },
       },
     },


### PR DESCRIPTION
## TLDR

This pull request adds reasoning configuration options to the settings schema and documentation. It allows users to configure reasoning behavior for models that support it, including effort level and token budget settings.

## Dive Deeper

This change introduces a new `reasoning` field in the generation configuration that allows users to control reasoning behavior in AI models. The configuration supports:
- Disabling reasoning entirely by setting it to `false`
- Configuring reasoning effort level with options for "low", "medium", or "high"
- Optionally setting a budget for reasoning token usage
- A new `samplingParams` field was also added to allow more granular control over generation parameters

The changes update both the TypeScript settings schema and the documentation to reflect these new configuration options.

## Reviewer Test Plan

1. Check that the updated settings schema correctly validates reasoning configuration options
2. Verify that the documentation accurately describes the new configuration options
3. Test that the configuration works as expected in the application when setting different reasoning effort levels
4. Confirm that setting reasoning to `false` properly disables reasoning functionality

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
